### PR TITLE
A small fix for a JSON::XS oddity

### DIFF
--- a/lib/WebService/Solr/Document.pm
+++ b/lib/WebService/Solr/Document.pm
@@ -41,9 +41,9 @@ sub _parse_fields {
         }
 
         my $v = shift @fields;
-        my @values = ( ref $v and !blessed $v ) ? @$v : ( "$v" );
+        my @values = ( ref $v and !blessed $v ) ? @$v : $v;
         push @new_fields,
-            map { WebService::Solr::Field->new( $f => $_ ) } @values;
+            map { WebService::Solr::Field->new( $f => "$_" ) } @values;
     }
 
     return @new_fields;

--- a/t/document.t
+++ b/t/document.t
@@ -1,4 +1,4 @@
-use Test::More tests => 23;
+use Test::More tests => 25;
 
 use strict;
 use warnings;
@@ -7,6 +7,8 @@ BEGIN {
     use_ok( 'WebService::Solr::Document' );
     use_ok( 'WebService::Solr::Field' );
 }
+
+use JSON::XS;
 
 my @fields = (
     [ id     => 1,               { boost => 1.6 } ],
@@ -125,4 +127,12 @@ my @field_objs = map { WebService::Solr::Field->new( @$_ ) } @fields;
 {
     my $doc = WebService::Solr::Document->new( @fields[ 0 .. 4 ] );
     is_deeply([ sort($doc->field_names) ], [ qw(id manu name sku weight)], 'field_names');
+}
+
+{
+    my $doc = WebService::Solr::Document->new(
+        bools => decode_json(q/{"arr": [true,false,true]}/)->{arr}
+    );
+    isa_ok( $doc, 'WebService::Solr::Document' );
+    is_deeply([1,0,1], [$doc->values_for('bools')], 'boolean arrays');
 }


### PR DESCRIPTION
Hi bricas & jib,

I've patched WebService::Solr::Document to handle values in the document which are arrays of booleans. Previously it would die horribly as the booleans are objects which trip a type constraint, I've explained it in the commit message a bit better.

Also if you want a hand maintaining WebService::Solr let me know as we're actively using it here at work (Venda Ltd).

Cheers,
Dan Brook aka broquaint
