### PR TITLE
Add the last_response attribute to WebService::Solr.

### DIFF
--- a/t/request/add.t
+++ b/t/request/add.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 10;
+use Test::More tests => 12;
 use Test::Mock::LWP;
 
 use XML::Simple;
@@ -22,8 +22,10 @@ isa_ok( $solr, 'WebService::Solr' );
 my $expect;
 
 {
+    is $solr->last_response, undef, "The last_response attribute hasn't been set yet";
     $expect = { doc => { field => { name => 'foo', content => 'bar' } } };
     $solr->add( { foo => 'bar' } );
+    isa_ok $solr->last_response, 'WebService::Solr::Response';
     $solr->update( { foo => 'bar' } );
 }
 

--- a/t/request/ping.t
+++ b/t/request/ping.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 3;
+use Test::More tests => 5;
 use Test::Mock::LWP;
 
 $Mock_ua->mock(
@@ -20,7 +20,9 @@ my $expect;
 
 {
     $expect = 'http://localhost:8983/solr/admin/ping?wt=json';
+    is $solr->last_response, undef, "The last_response attribute hasn't been set yet";
     $solr->ping();
+    isa_ok $solr->last_response, 'WebService::Solr::Response';
 }
 
 sub _test_req {

--- a/t/request/search.t
+++ b/t/request/search.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 4;
+use Test::More tests => 6;
 use Test::Mock::LWP;
 
 $Mock_ua->mock(
@@ -21,7 +21,9 @@ my ( $expect_path, $expect_params );
 {
     $expect_path = '/solr/select';
     $expect_params = { wt => 'json', q => 'foo' };
+    is $solr->last_response, undef, "The last_response attribute hasn't been set yet";
     $solr->search( 'foo' );
+    isa_ok $solr->last_response, 'WebService::Solr::Response';
 }
 
 sub _test_req {


### PR DESCRIPTION
This attribute allows callers to see what came back in the last response
from the server whilst maintaining the existing API. So now when the likes
of add() returns false one can access last_response to see why that might be.

@bricas this is another approach WRT the message I sent you yesterday. It's the least worst IMO.

If further context is needed on this work then I'm happy to provide it.

Cheers,
Dan
