### PR TITLE
use Any::Moose instead of Moose to allow Mouse instead

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ requires 'Data::Page';
 requires 'Data::Pageset';
 requires 'XML::Easy';
 requires 'JSON::XS';
-requires 'Moose';
+requires 'Any::Moose';
 requires 'Encode';
 
 test_requires 'Test::More';

--- a/lib/WebService/Solr.pm
+++ b/lib/WebService/Solr.pm
@@ -1,6 +1,6 @@
 package WebService::Solr;
 
-use Moose;
+use Any::Moose;
 
 use Encode qw(encode);
 use URI;
@@ -194,7 +194,7 @@ sub _send_update {
     return $self->last_response;
 }
 
-no Moose;
+no Any::Moose;
 
 __PACKAGE__->meta->make_immutable;
 

--- a/lib/WebService/Solr/Query.pm
+++ b/lib/WebService/Solr/Query.pm
@@ -1,6 +1,6 @@
 package WebService::Solr::Query;
 
-use Moose;
+use Any::Moose;
 
 use overload q("") => 'stringify';
 
@@ -270,7 +270,7 @@ sub ___log {
     print "# $who: $msg\n";
 }
 
-no Moose;
+no Any::Moose;
 
 __PACKAGE__->meta->make_immutable;
 

--- a/lib/WebService/Solr/Response.pm
+++ b/lib/WebService/Solr/Response.pm
@@ -1,6 +1,6 @@
 package WebService::Solr::Response;
 
-use Moose;
+use Any::Moose;
 
 use WebService::Solr::Document;
 use Data::Page;
@@ -136,7 +136,7 @@ sub ok {
     return defined $status && $status == 0;
 }
 
-no Moose;
+no Any::Moose;
 
 __PACKAGE__->meta->make_immutable;
 


### PR DESCRIPTION
Would you mind considering this patch?  It changes from Moose to Any::Moose so that the 
user can choose to use lightweight Mouse instead of Moose. It looks like WebService::Solr 
just uses Moose to avoid having hand-written new() methods, so it shouldn't really
change very much.  The unit tests all still pass.

I left any documentation changes up to you.

Thanks!
