### PR TITLE
Changing the http method used for queries from a get to a post.

### DIFF
--- a/lib/WebService/Solr.pm
+++ b/lib/WebService/Solr.pm
@@ -158,7 +158,9 @@ sub generic_solr_request {
     $params ||= {};
     return $self->last_response(
         WebService::Solr::Response->new(
-            $self->agent->get( $self->_gen_url( $path, $params ) ) ) );
+            $self->agent->post(
+                $self->_gen_url( $path ),
+                $params ) ) );
 }
 
 sub _gen_url {

--- a/t/request/search.t
+++ b/t/request/search.t
@@ -1,12 +1,12 @@
 use strict;
 use warnings;
 
-use Test::More tests => 6;
+use Test::More tests => 7;
 use Test::Mock::LWP;
 
 $Mock_ua->mock(
-    get => sub {
-        _test_req( $_[ 1 ] );
+    post => sub {
+        _test_req( $_[ 1 ], $_[ 2 ] );
         return HTTP::Response->new;
     }
 );
@@ -16,11 +16,12 @@ use_ok( 'WebService::Solr' );
 my $solr = WebService::Solr->new();
 isa_ok( $solr, 'WebService::Solr' );
 
-my ( $expect_path, $expect_params );
+my ( $expect_path, $expect_url, $expect_params );
 
 {
     $expect_path = '/solr/select';
-    $expect_params = { wt => 'json', q => 'foo' };
+    $expect_url = { wt => 'json' };
+    $expect_params = { q => 'foo' };
     is $solr->last_response, undef, "The last_response attribute hasn't been set yet";
     $solr->search( 'foo' );
     isa_ok $solr->last_response, 'WebService::Solr::Response';
@@ -28,5 +29,6 @@ my ( $expect_path, $expect_params );
 
 sub _test_req {
     is( $_[ 0 ]->path, $expect_path, ' search() path ' );
-    is_deeply( { $_[ 0 ]->query_form }, $expect_params, ' search() params ' );
+    is_deeply( { $_[ 0 ]->query_form }, $expect_url, ' search() params ' );
+    is_deeply( $_[ 1 ], $expect_params, ' search() params ' );
 }


### PR DESCRIPTION
This fixes a problem with the Solr server being unable to accept
especially long urls.  
