### PR TITLE
Added 'update' option

### DIFF
--- a/lib/WebService/Solr/Field.pm
+++ b/lib/WebService/Solr/Field.pm
@@ -38,9 +38,16 @@ sub boost {
     return $self->{ boost };
 }
 
+sub update {
+    my $self = shift;
+    $self->{ update } = $_[ 0 ] if @_;
+    return $self->{ update };
+}
+
 sub to_element {
     my $self = shift;
     my %attr = ( $self->boost ? ( boost => $self->boost ) : () );
+    $attr{update} = $self->update if $self->update;
 
     return XML::Easy::Element->new(
         'field',
@@ -81,6 +88,8 @@ name-value pair.
 =item * value - the field's value
 
 =item * boost - a floating-point boost value
+
+=item * update - if field should be used to update a document, can be either 'set' or 'add' (for multiValued fields). For Solr version 4 or above.
 
 =back
 

--- a/t/field.t
+++ b/t/field.t
@@ -1,4 +1,4 @@
-use Test::More tests => 9;
+use Test::More tests => 12;
 
 use strict;
 use warnings;
@@ -14,13 +14,33 @@ use WebService::Solr::Field;
 {
     my $f = WebService::Solr::Field->new( id => '0001', { boost => 3 } );
     my $expected = '<field boost="3" name="id">0001</field>';
-    is( $f->to_xml, $expected, 'to_xml(), all attrs' );
+    is( $f->to_xml, $expected, 'to_xml(), boost attrs' );
 }
 
 {
     my $f = WebService::Solr::Field->new( id => '0001', { boost => 3.1 } );
     my $expected = '<field boost="3.1" name="id">0001</field>';
-    is( $f->to_xml, $expected, 'to_xml(), all attrs, float for boost' );
+    is( $f->to_xml, $expected, 'to_xml(), float for boost attrs' );
+}
+
+{
+    my $f = WebService::Solr::Field->new( author => 'John', { update => 'set' } );
+    my $expected = '<field name="author" update="set">John</field>';
+    is( $f->to_xml, $expected, 'to_xml(), update attrs, set for update' );
+}
+
+{
+    my $f = WebService::Solr::Field->new( author => 'John', { update => 'add' } );
+    my $expected = '<field name="author" update="add">John</field>';
+    is( $f->to_xml, $expected, 'to_xml(), update attrs, add for update' );
+}
+
+{
+    my $f = WebService::Solr::Field->new( author => 'John', 
+        { update => 'set', boost => '3.1' } );
+    my $expected = '<field boost="3.1" name="author" update="set">John</field>';
+    is( $f->to_xml, $expected, 
+        'to_xml(), all attrs, add for update and float for boost' );
 }
 
 {


### PR DESCRIPTION
In order to update "Documents" I added an "update" option to the Field module which can be used with Solr 4. A Field can have the "update" either set to "set" or "add" if the field is specified as multiValued.

Cheers,
Joakim 
