### PR TITLE
Port to Moo + Types::Standard

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl extension WebService::Solr.
 
+ - Switch from the deprecated Any::Moose to Moo + Types::Standard
+
 0.23 2014-02-07 16:58
  - Fix a bug in Webservice::Solr::Query::stringify() where it would
    sometimes modify the query argument structure passed in.  This would

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,8 @@ requires 'Data::Page';
 requires 'Data::Pageset';
 requires 'XML::Easy';
 requires 'JSON::XS';
-requires 'Any::Moose' => '0.16'; # 0.16 doesn't force Mouse dep
+requires 'Moo';
+requires 'Types::Standard' => '0.008'; # InstanceOf type constraint
 requires 'Encode';
 
 test_requires 'Test::More' => '0.94', # want note(), explain(), subtest() and done_testing()

--- a/lib/WebService/Solr/Field.pm
+++ b/lib/WebService/Solr/Field.pm
@@ -93,7 +93,7 @@ Creates a new field object. Currently, the only option available is a
 
 =head2 BUILDARGS( @args )
 
-A Moose override to allow our custom constructor.
+A Moo override to allow our custom constructor.
 
 =head2 to_element( )
 

--- a/lib/WebService/Solr/Query.pm
+++ b/lib/WebService/Solr/Query.pm
@@ -1,12 +1,14 @@
 package WebService::Solr::Query;
 
-use Any::Moose;
+use Moo;
+
+use Types::Standard qw(ArrayRef);
 
 use overload q("") => 'stringify';
 
 my $escape_chars = quotemeta( '+-&|!(){}[]^"~*?:\\' );
 
-has 'query' => ( is => 'ro', isa => 'ArrayRef', default => sub { [] } );
+has 'query' => ( is => 'ro', isa => ArrayRef, default => sub { [] } );
 
 use constant D => 0;
 
@@ -276,9 +278,7 @@ sub __dumper {
     return Data::Dumper::Dumper( @_ );
 }
 
-no Any::Moose;
-
-__PACKAGE__->meta->make_immutable;
+no Moo;
 
 1;
 
@@ -427,7 +427,7 @@ Debugging constant, default: off.
 
 =head2 BUILDARGS
 
-Moose method to handle input to C<new()>.
+Moo method to handle input to C<new()>.
 
 =head1 SEE ALSO
 

--- a/lib/WebService/Solr/Response.pm
+++ b/lib/WebService/Solr/Response.pm
@@ -1,7 +1,8 @@
 package WebService::Solr::Response;
 
-use Any::Moose;
+use Moo;
 
+use Types::Standard qw(Object HashRef Maybe InstanceOf ArrayRef);
 use WebService::Solr::Document;
 use Data::Page;
 use Data::Pageset;
@@ -9,7 +10,7 @@ use JSON::XS ();
 
 has 'raw_response' => (
     is      => 'ro',
-    isa     => 'Object',
+    isa     => Object,
     handles => {
         status_code    => 'code',
         status_message => 'message',
@@ -18,17 +19,23 @@ has 'raw_response' => (
     },
 );
 
-has 'content' => ( is => 'rw', isa => 'HashRef', lazy_build => 1 );
+has 'content' => ( is => 'rw', isa => HashRef, lazy => 1, builder => 1 );
 
 has 'docs' =>
-    ( is => 'rw', isa => 'ArrayRef', auto_deref => 1, lazy_build => 1 );
+    ( is => 'rw', isa => ArrayRef, lazy => 1, builder => 1 );
 
-has 'pager' => ( is => 'rw', isa => 'Maybe[Data::Page]', lazy_build => 1 );
+around docs => sub {
+    my ($orig, $self, @args) = @_;
+    my $ret = $self->$orig(@args);
+    return wantarray ? @$ret : $ret;
+};
+
+has 'pager' => ( is => 'rw', isa => Maybe[InstanceOf['Data::Page']], lazy => 1, builder => 1 );
 
 has '_pageset_slide' =>
-    ( is => 'rw', isa => 'Maybe[Data::Pageset]', lazy_build => 1 );
+    ( is => 'rw', isa => Maybe[InstanceOf['Data::Pageset']], lazy => 1, builder => 1, predicate => 1 );
 has '_pageset_fixed' =>
-    ( is => 'rw', isa => 'Maybe[Data::Pageset]', lazy_build => 1 );
+    ( is => 'rw', isa => Maybe[InstanceOf['Data::Pageset']], lazy => 1, builder => 1, predicate => 1 );
 
 sub BUILDARGS {
     my ( $self, $res ) = @_;
@@ -136,9 +143,7 @@ sub ok {
     return defined $status && $status == 0;
 }
 
-no Any::Moose;
-
-__PACKAGE__->meta->make_immutable;
+no Moo;
 
 1;
 
@@ -187,7 +192,7 @@ required.
 
 =head2 BUILDARGS( @args )
 
-A Moose override to allow our custom constructor.
+A Moo override to allow our custom constructor.
 
 =head2 facet_counts( )
 

--- a/lib/WebService/Solr/Response.pm
+++ b/lib/WebService/Solr/Response.pm
@@ -19,10 +19,10 @@ has 'raw_response' => (
     },
 );
 
-has 'content' => ( is => 'rw', isa => HashRef, lazy => 1, builder => 1 );
+has 'content' => ( is => 'lazy', isa => HashRef );
 
 has 'docs' =>
-    ( is => 'rw', isa => ArrayRef, lazy => 1, builder => 1 );
+    ( is => 'lazy', isa => ArrayRef );
 
 around docs => sub {
     my ($orig, $self, @args) = @_;
@@ -30,12 +30,12 @@ around docs => sub {
     return wantarray ? @$ret : $ret;
 };
 
-has 'pager' => ( is => 'rw', isa => Maybe[InstanceOf['Data::Page']], lazy => 1, builder => 1 );
+has 'pager' => ( is => 'lazy', isa => Maybe[InstanceOf['Data::Page']] );
 
 has '_pageset_slide' =>
-    ( is => 'rw', isa => Maybe[InstanceOf['Data::Pageset']], lazy => 1, builder => 1, predicate => 1 );
+    ( is => 'rw', isa => Maybe[InstanceOf['Data::Pageset']], predicate => 1 );
 has '_pageset_fixed' =>
-    ( is => 'rw', isa => Maybe[InstanceOf['Data::Pageset']], lazy => 1, builder => 1, predicate => 1 );
+    ( is => 'rw', isa => Maybe[InstanceOf['Data::Pageset']], predicate => 1 );
 
 sub BUILDARGS {
     my ( $self, $res ) = @_;


### PR DESCRIPTION
Any::Moose is deprecated in favour of Moo, which integrates much better with both Moose and Mouse.
Use Types::Standard for the type constraints, and clean up the Response API a bit.
