### PR TITLE
Include Carp so that the confess works

### DIFF
--- a/lib/WebService/Solr.pm
+++ b/lib/WebService/Solr.pm
@@ -13,6 +13,7 @@ use HTTP::Headers;
 use XML::Easy::Element;
 use XML::Easy::Content;
 use XML::Easy::Text ();
+use Carp qw(confess);
 
 has 'url' => (
     is      => 'ro',
@@ -194,7 +195,7 @@ sub _send_update {
 
     my $http_response = $self->agent->request( $req );
     if ( $http_response->is_error ) {
-        confess $http_response->status_line . ': ' . $http_response->content;
+        confess($http_response->status_line . ': ' . $http_response->content);
     }
 
     $self->last_response( WebService::Solr::Response->new( $http_response ) );


### PR DESCRIPTION
We run into the following error a lot in production:

`Can't locate object method "confess" via package "HTTP::Headers" at /opt/perl/lib/site_perl/5.20.1/HTTP/Message.pm line 652`

It happens when we get a HTTP error from Solr.