### PR TITLE
Optionally parse with JSON::PP

### DIFF
--- a/lib/WebService/Solr.pm
+++ b/lib/WebService/Solr.pm
@@ -15,6 +15,12 @@ use XML::Easy::Content;
 use XML::Easy::Text ();
 use Carp qw(confess);
 
+has 'PP' => (
+    is      => 'ro',
+    isa     => Bool,
+    default => 0
+);
+
 has 'url' => (
     is      => 'ro',
     isa     => InstanceOf['URI'],
@@ -198,7 +204,7 @@ sub _send_update {
         confess($http_response->status_line . ': ' . $http_response->content);
     }
 
-    $self->last_response( WebService::Solr::Response->new( $http_response ) );
+    $self->last_response( WebService::Solr::Response->new( $http_response, (PP=>$self->{PP}) ) );
 
     $self->commit if $autocommit;
 

--- a/lib/WebService/Solr/Response.pm
+++ b/lib/WebService/Solr/Response.pm
@@ -7,6 +7,13 @@ use WebService::Solr::Document;
 use Data::Page;
 use Data::Pageset;
 use JSON::XS ();
+use JSON::PP ();
+
+has 'PP' => (
+    is      => 'ro',
+    isa     => Bool,
+    default => 0
+);
 
 has 'raw_response' => (
     is      => 'ro',
@@ -46,7 +53,11 @@ sub _build_content {
     my $self    = shift;
     my $content = $self->raw_response->content;
     return {} unless $content;
-    my $rv = eval { JSON::XS::decode_json( $content ) };
+    my $rv;
+    if($self->{PP})
+    { $rv = eval { JSON::PP::decode_json( $content ) }; }
+    else
+    { $rv = eval { JSON::XS::decode_json( $content ) }; }
 
     ### JSON::XS throw an exception, but kills most of the content
     ### in the diagnostic, making it hard to track down the problem


### PR DESCRIPTION
In upgrading from Debian Wheezy to Debian Stretch, I found that my script that runs WebService::Solr no longer worked: JSON::XS in WebService::Solr::Response always failed to parse the response, even when the response was perfectly valid.  I believe this is because my script is multi-threaded, and JSON::XS is not guaranteed thread-safe.  JSON::PP works perfectly.

This pull request implements an option to allow WebService::Solr to use JSON::PP.  There may be a better way of achieving this.

Thank you for WebService::Solr!
