### PR TITLE
Add handling of Result Grouping Solr responses.

### DIFF
--- a/lib/WebService/Solr.pm
+++ b/lib/WebService/Solr.pm
@@ -29,7 +29,7 @@ has 'autocommit' => ( is => 'ro', isa => Bool, default => 1 );
 has 'default_params' => (
     is         => 'ro',
     isa        => HashRef,
-    default    => sub { { wt => 'json' } }
+    default    => sub { { wt => 'json', echoParams => 'explicit' } }
 );
 
 around default_params => sub {
@@ -43,7 +43,7 @@ has 'last_response' => (
     isa => Maybe[InstanceOf['WebService::Solr::Response']],
 );
 
-our $VERSION = '0.42';
+our $VERSION = '0.43';
 
 sub BUILDARGS {
     my ( $self, $url, $options ) = @_;


### PR DESCRIPTION
Handling of Solr Result Grouping feature was added to WebService::Solr.  The response data structure could differ greatly from the typical response structure depending on the request fields passed.  Methods were added to properly access documents analogous to existing methods; see code and/or perldoc for specifics.  Integration of group data with Data::Page wasn't performed as this feature isn't used at our company and appropriate testing of that enhancement couldn't be done.

No other Perl library currently handles grouping for Solr and since we already were using this for basic Solr queries it was an easy decision to add this ability.  It is backwards compatible and gives appropriate results if called and grouping isn't used.  Thanks.